### PR TITLE
Fix captcha validation on CF7 4.1

### DIFF
--- a/includes/class-bwp-recaptcha-cf7.php
+++ b/includes/class-bwp-recaptcha-cf7.php
@@ -276,7 +276,7 @@ class BWP_RECAPTCHA_CF7
 			|| !isset($_POST['recaptcha_response_field'])
 		) {
 			$result['valid'] = false;
-			$result['reason'][$name] = $rc->options['input_error'];
+			$result['reason'] = array($name => $rc->options['input_error']);
 		}
 
 		// load the recaptcha PHP library just in case
@@ -292,7 +292,7 @@ class BWP_RECAPTCHA_CF7
 		if (!$response->is_valid) {
 			// invalid captcha response, show an error message
 			$result['valid'] = false;
-			$result['reason'][$name] = $rc->options['input_error'];
+			$result['reason'] = array($name => $rc->options['input_error']);
 		}
 
 		return $result;


### PR DESCRIPTION
This is the fix suggested by ivomokros in 
https://wordpress.org/support/topic/no-longer-works-with-cf7-41?replies=25