### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/bwp-recaptcha.php
+++ b/bwp-recaptcha.php
@@ -37,7 +37,7 @@ else
 
 // @since 2.0.0 we hook to 'init' action with a priority of 9 to make sure the
 // plugin loads before Contact Form 7 loads
-add_filter('bwp_capt_init_priority', create_function('', 'return 9;'));
+add_filter('bwp_capt_init_priority', function() { return 9; });
 
 // init the plugin
 $bwp_capt = new BWP_RECAPTCHA($bwp_capt_meta);

--- a/includes/class-bwp-recaptcha.php
+++ b/includes/class-bwp-recaptcha.php
@@ -1569,7 +1569,7 @@ class BWP_RECAPTCHA extends BWP_Framework_V3
 			if ($this->_is_previous_comment_spam())
 			{
 				// do not increase Akismet spam counter
-				add_filter('akismet_spam_count_incr', create_function('', 'return 0;'), 11);
+				add_filter('akismet_spam_count_incr', function() { return 0; }, 11);
 
 				// use the correct status for the marked-as-spam comment, use
 				// workaround for remove_filter function


### PR DESCRIPTION
Addresses issues in #30; does NOT touch `includes/provider/recaptcha/*` (reCAPTCHA v1 is no longer usable anyway, and PHP 7.x will use reCAPTCHA from `vendor/`)